### PR TITLE
compiler: auto orient processed images

### DIFF
--- a/compiler/src/Processors.hs
+++ b/compiler/src/Processors.hs
@@ -86,7 +86,11 @@ resizePictureUpTo maxResolution inputPath outputPath =
     maxSize Resolution{width, height} = show width ++ "x" ++ show height ++ ">"
 
     resize :: FileName -> FileName -> IO ()
-    resize input output = callProcess "magick" [input, "-resize", maxSize maxResolution, output]
+    resize input output = callProcess "magick"
+      [ input
+      , "-auto-orient"
+      , "-resize", maxSize maxResolution
+      , output ]
 
 
 type Cache = FileProcessor -> FileProcessor


### PR DESCRIPTION
Let ImageMagick re-orient images based on EXIF metadata.
Some web browsers still don't support that correctly.

GitHub: closes #67