### PR TITLE
compiler: optimise dir diff for output cleanup

### DIFF
--- a/compiler/package.yaml
+++ b/compiler/package.yaml
@@ -17,6 +17,7 @@ description:         Please see the README on GitHub at <https://github.com/paci
 dependencies:
 - base >= 4.7 && < 5
 - containers
+- data-ordlist
 - filepath
 - directory
 - text


### PR DESCRIPTION
n log n by sorting instead of silly n^2

GitHub: closes #70

`time ldgallery -c`  on a test gallery with 10000 dummy files:
* before: `51,50s user 58,36s system 511% cpu 21,487 total`
* after: `5,51s user 1,71s system 425% cpu 1,697 total`

@OzoneGrif Please test this on your big gallery (with the `--clean-output` flag).