### PR TITLE
viewer: styling

### DIFF
--- a/viewer/public/index.html
+++ b/viewer/public/index.html
@@ -24,6 +24,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="generator" content="ldgallery">
   <link rel="icon" href="<%= BASE_URL %>favicon.ico">
   <title>ldgallery</title>
 </head>

--- a/viewer/src/assets/scss/global.scss
+++ b/viewer/src/assets/scss/global.scss
@@ -23,12 +23,16 @@
 
 // === Forms
 
-.input {
-  background-color: $input-background-color;
-  color: $text !important;
+.taginput {
+    .is-delete {
+      background-color: $input-tag-delete-background-color !important;
 
-  &::placeholder {
-    color: $text-light !important;
+      &:hover {
+        color: $link-hover;
+      }
+  }
+  .autocomplete .dropdown-content {
+    max-height: 300px;
   }
 }
 
@@ -67,6 +71,10 @@
   color: $disabled-color !important;
 }
 
+.title {
+  margin: 0.2em 0.5em !important;
+}
+
 // touch devices fixes
 @media (hover:none), (hover:on-demand) {
   .link:hover {
@@ -84,8 +92,8 @@
   overflow: auto;
 }
 .scrollbar::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
 }
 .scrollbar::-webkit-scrollbar-corner {
   background-color: transparent;

--- a/viewer/src/assets/scss/global.scss
+++ b/viewer/src/assets/scss/global.scss
@@ -2,6 +2,7 @@
 --             pictures into a searchable web gallery.
 --
 -- Copyright (C) 2019-2020  Guillaume FOUET
+--               2020       Pacien TRAN-GIRARD
 --
 -- This program is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as
@@ -21,6 +22,15 @@
 @import "@/assets/scss/theme.scss";
 
 // === Forms
+
+.input {
+  background-color: $input-background-color;
+  color: $text !important;
+
+  &::placeholder {
+    color: $text-light !important;
+  }
+}
 
 .required label::after {
   content: "*";
@@ -47,15 +57,10 @@
   align-items: center;
 }
 
-// === Links
+// === Text
 
-.link {
-  color: $link;
-  cursor: pointer;
-  text-decoration: none;
-  &:hover {
-    color: $link-hover;
-  }
+.link:hover {
+  color: $link-hover;
 }
 
 .disabled {
@@ -68,15 +73,14 @@
   overflow: auto;
 }
 .scrollbar::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
 }
 .scrollbar::-webkit-scrollbar-corner {
   background-color: transparent;
 }
 .scrollbar::-webkit-scrollbar-thumb {
-  box-shadow: inset 0 0 1px black;
-  background-color: $toolbar-color;
+  background-color: $scrollbar-color;
 }
 
 // === Thumbnail tiles alignment

--- a/viewer/src/assets/scss/global.scss
+++ b/viewer/src/assets/scss/global.scss
@@ -67,6 +67,17 @@
   color: $disabled-color !important;
 }
 
+// touch devices fixes
+@media (hover:none), (hover:on-demand) {
+  .link:hover {
+    color: $text !important;
+  }
+
+  .disabled:hover {
+    color: $disabled-color !important;
+  }
+}
+
 // === Scrollbar styling
 
 .scrollbar {

--- a/viewer/src/assets/scss/theme.scss
+++ b/viewer/src/assets/scss/theme.scss
@@ -80,7 +80,7 @@ $panel-left-bgcolor: $palette-700;
 $panel-left-txtcolor: $primary;
 $content-bgcolor: $palette-900;
 $scrollbar-color: $palette-050;
-$loader-color: $palette-050;
+$loader-color: $palette-800;
 $input-background-color: $palette-500;
 $input-active-outline-color: $palette-200;
 $input-tag-background-color: $palette-800;

--- a/viewer/src/assets/scss/theme.scss
+++ b/viewer/src/assets/scss/theme.scss
@@ -2,6 +2,7 @@
 --             pictures into a searchable web gallery.
 --
 -- Copyright (C) 2019-2020  Guillaume FOUET
+--               2020       Pacien TRAN-GIRARD
 --
 -- This program is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as
@@ -17,23 +18,74 @@
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-// === Theme
+// Material Design Gray colour palette
+/*
+$palette-000: #FFFFFF;
+$palette-050: #FAFAFA;
+$palette-100: #F5F5F5;
+$palette-200: #EEEEEE;
+$palette-300: #E0E0E0;
+$palette-400: #BDBDBD;
+$palette-500: #9E9E9E;
+$palette-600: #757575;
+$palette-700: #616161;
+$palette-800: #424242;
+$palette-900: #212121;
+*/
 
-$layout-top: 35px;
+// Material Design Blue Gray colour palette
+$palette-000: #FFFFFF;
+$palette-050: #ECEFF1;
+$palette-100: #CFD8DC;
+$palette-200: #B0BEC5;
+$palette-300: #90A4AE;
+$palette-400: #78909C;
+$palette-500: #607D8B;
+$palette-600: #546E7A;
+$palette-700: #455A64;
+$palette-800: #37474F;
+$palette-900: #263238;
+
+// Material Design Brown colour palette
+/*
+$palette-000: #FFFFFF;
+$palette-050: #EFEBE9;
+$palette-100: #D7CCC8;
+$palette-200: #BCAAA4;
+$palette-300: #A1887F;
+$palette-400: #8D6E63;
+$palette-500: #795548;
+$palette-600: #6D4C41;
+$palette-700: #5D4037;
+$palette-800: #4E342E;
+$palette-900: #3E2723;
+*/
+
+// Buefy components
+$primary: $palette-000;
+$text: $primary;
+$text-light: $palette-100;
+$text-strong: $primary;
+$link: $primary;
+$link-visited: $link;
+$link-hover: $palette-100;
+$disabled-color: $palette-400;
+$radius: 0;
+$loading-background: $palette-800;
+
+// Custom components
+$panel-top-bgcolor: $palette-800;
+$panel-top-txtcolor: $primary;
+$panel-left-bgcolor: $palette-700;
+$panel-left-txtcolor: $primary;
+$content-bgcolor: $palette-900;
+$scrollbar-color: $palette-050;
+$loader-color: $palette-050;
+$input-background-color: $palette-500;
+$input-active-outline-color: $palette-200;
+$input-tag-background-color: $palette-800;
+$input-tag-delete-background-color: $palette-700;
+
+// Layout
+$layout-top: 45px;
 $layout-left: 250px;
-
-$panel-top-bgcolor: #225;
-$panel-top-txtcolor: white;
-$panel-left-bgcolor: $panel-top-bgcolor;
-$panel-left-txtcolor: $panel-top-txtcolor;
-$content-bgcolor: #1e1e1e;
-$toolbar-color: #d62929;
-$loader-color: #272727;
-
-// Overrides - Buefy
-$link: $panel-top-txtcolor;
-$link-hover: lightblue;
-$disabled-color: #656589;
-$control-radius: 0;
-$input-radius: 0;
-$loading-background: $panel-top-bgcolor;

--- a/viewer/src/assets/scss/theme.scss
+++ b/viewer/src/assets/scss/theme.scss
@@ -18,20 +18,7 @@
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-// Material Design Gray colour palette
-/*
-$palette-000: #FFFFFF;
-$palette-050: #FAFAFA;
-$palette-100: #F5F5F5;
-$palette-200: #EEEEEE;
-$palette-300: #E0E0E0;
-$palette-400: #BDBDBD;
-$palette-500: #9E9E9E;
-$palette-600: #757575;
-$palette-700: #616161;
-$palette-800: #424242;
-$palette-900: #212121;
-*/
+@import '_buefy_variables.scss';
 
 // Material Design Blue Gray colour palette
 $palette-000: #FFFFFF;
@@ -46,44 +33,35 @@ $palette-700: #455A64;
 $palette-800: #37474F;
 $palette-900: #263238;
 
-// Material Design Brown colour palette
-/*
-$palette-000: #FFFFFF;
-$palette-050: #EFEBE9;
-$palette-100: #D7CCC8;
-$palette-200: #BCAAA4;
-$palette-300: #A1887F;
-$palette-400: #8D6E63;
-$palette-500: #795548;
-$palette-600: #6D4C41;
-$palette-700: #5D4037;
-$palette-800: #4E342E;
-$palette-900: #3E2723;
-*/
-
 // Buefy components
 $primary: $palette-000;
 $text: $primary;
 $text-light: $palette-100;
 $text-strong: $primary;
+$input-color: $text;
+$input-shadow: none;
+$input-border-color: transparent;
+$input-background-color: $palette-500;
+$input-focus-box-shadow-color: $palette-200;
 $link: $primary;
 $link-visited: $link;
 $link-hover: $palette-100;
 $disabled-color: $palette-400;
 $radius: 0;
 $loading-background: $palette-800;
+$title-color: $palette-200;
+$title-size: $size-5;
+$tag-background-color: $palette-800;
+
 
 // Custom components
 $panel-top-bgcolor: $palette-800;
 $panel-top-txtcolor: $primary;
-$panel-left-bgcolor: $palette-700;
+$panel-left-bgcolor: $palette-800;
 $panel-left-txtcolor: $primary;
 $content-bgcolor: $palette-900;
-$scrollbar-color: $palette-050;
+$scrollbar-color: $palette-300;
 $loader-color: $palette-800;
-$input-background-color: $palette-500;
-$input-active-outline-color: $palette-200;
-$input-tag-background-color: $palette-800;
 $input-tag-delete-background-color: $palette-700;
 
 // Layout

--- a/viewer/src/components/LdBreadcrumb.vue
+++ b/viewer/src/components/LdBreadcrumb.vue
@@ -25,7 +25,7 @@
         <fa-icon class="ld-breadcrumb-element-icon" :icon="getIcon(item)" size="lg" />
         {{item.title}}
       </router-link>
-      <span class="ld-breadcrumb-path-separator"><fa-icon icon="angle-right" /></span>
+      <span class="ld-breadcrumb-path-separator disabled"><fa-icon icon="angle-right" /></span>
     </li>
   </ul>
 </template>
@@ -65,7 +65,7 @@ export default class LdBreadcrumb extends Vue {
       text-overflow: ellipsis;
 
       .ld-breadcrumb-element-icon {
-        margin-right: 5px;
+        margin-right: 2px;
       }
     }
 

--- a/viewer/src/components/LdBreadcrumb.vue
+++ b/viewer/src/components/LdBreadcrumb.vue
@@ -21,7 +21,7 @@
 <template>
   <ul class="ld-breadcrumb">
     <li v-for="item in $galleryStore.currentItemPath" :key="item.path">
-      <router-link :to="item.path" class="ld-breadcrumb-link">
+      <router-link :to="item.path" class="ld-breadcrumb-link link">
         <fa-icon class="ld-breadcrumb-element-icon" :icon="getIcon(item)" size="lg" />
         {{item.title}}
       </router-link>

--- a/viewer/src/components/LdBreadcrumb.vue
+++ b/viewer/src/components/LdBreadcrumb.vue
@@ -2,6 +2,7 @@
 --             pictures into a searchable web gallery.
 --
 -- Copyright (C) 2019-2020  Guillaume FOUET
+--               2020       Pacien TRAN-GIRARD
 --
 -- This program is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as
@@ -19,12 +20,12 @@
 
 <template>
   <ul class="ld-breadcrumb">
-    <li v-for="(item,idx) in $galleryStore.currentItemPath" :key="item.path">
-      <router-link :to="item.path">
-        <fa-icon :icon="getIcon(item)" size="lg" />
+    <li v-for="item in $galleryStore.currentItemPath" :key="item.path">
+      <router-link :to="item.path" class="ld-breadcrumb-link">
+        <fa-icon class="ld-breadcrumb-element-icon" :icon="getIcon(item)" size="lg" />
         {{item.title}}
       </router-link>
-      <fa-icon v-if="(idx+1) < $galleryStore.currentItemPath.length" icon="angle-right" />
+      <span class="ld-breadcrumb-path-separator"><fa-icon icon="angle-right" /></span>
     </li>
   </ul>
 </template>
@@ -43,18 +44,50 @@ export default class LdBreadcrumb extends Vue {
 
 <style lang="scss">
 @import "@/assets/scss/theme.scss";
+@import "@/assets/scss/_buefy_variables.scss";
 
 .ld-breadcrumb {
-  border-left: 1px solid $disabled-color;
-  padding-left: 15px;
-  display: flex;
   list-style: none;
-  margin: 5px;
-  a {
-    margin-right: 5px;
-  }
-  li:not(:first-child) {
+  vertical-align: middle;
+  display: flex;
+  flex-wrap: nowrap;
+  overflow: hidden;
+  padding: 0 7px;
+
+  > li {
+    line-height: $layout-top;
+    overflow: hidden;
+    display: flex;
+
+    .ld-breadcrumb-link {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+
+      .ld-breadcrumb-element-icon {
+        margin-right: 5px;
+      }
+    }
+
     margin-left: 10px;
+    .ld-breadcrumb-path-separator {
+      margin-left: 10px;
+    }
+
+    flex: 0 100 auto;
+    &:last-child {
+      flex: 0 1 auto;
+
+      .ld-breadcrumb-path-separator {
+        display: none;
+      }
+    }
+  }
+
+  @media only screen and (max-width: $tablet) {
+    > li:not(:last-child) {
+      display: none;
+    }
   }
 }
 </style>

--- a/viewer/src/components/LdBreadcrumb.vue
+++ b/viewer/src/components/LdBreadcrumb.vue
@@ -19,75 +19,55 @@
 -->
 
 <template>
-  <ul class="ld-breadcrumb">
-    <li v-for="item in $galleryStore.currentItemPath" :key="item.path">
-      <router-link :to="item.path" class="ld-breadcrumb-link link">
-        <fa-icon class="ld-breadcrumb-element-icon" :icon="getIcon(item)" size="lg" />
+  <ul ref="breadcrumb" class="ld-breadcrumb scrollbar" v-dragscroll>
+    <li v-for="(item,idx) in $galleryStore.currentItemPath" :key="item.path">
+      <router-link :to="item.path" class="link">
+        <fa-icon :icon="getIcon(item)" size="lg" />
         {{item.title}}
       </router-link>
-      <span class="ld-breadcrumb-path-separator disabled"><fa-icon icon="angle-right" /></span>
+      <fa-icon
+        v-if="(idx+1) < $galleryStore.currentItemPath.length"
+        icon="angle-right"
+        class="disabled"
+      />
     </li>
   </ul>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from "vue-property-decorator";
+import { Component, Vue, Ref } from "vue-property-decorator";
 import Tools from "@/tools";
 
 @Component
 export default class LdBreadcrumb extends Vue {
+  @Ref() readonly breadcrumb!: HTMLUListElement;
+
   getIcon(item: Gallery.Item) {
     return Tools.getIcon(item);
+  }
+
+  updated() {
+    this.breadcrumb.scrollLeft = this.breadcrumb.scrollWidth;
   }
 }
 </script>
 
 <style lang="scss">
 @import "@/assets/scss/theme.scss";
-@import "@/assets/scss/_buefy_variables.scss";
 
 .ld-breadcrumb {
-  list-style: none;
-  vertical-align: middle;
+  border-left: 1px solid $disabled-color;
+  padding-left: 15px;
+  margin: 5px;
   display: flex;
-  flex-wrap: nowrap;
-  overflow: hidden;
-  padding: 0 7px;
+  align-items: center;
+  white-space: nowrap;
 
-  > li {
-    line-height: $layout-top;
-    overflow: hidden;
-    display: flex;
-
-    .ld-breadcrumb-link {
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-
-      .ld-breadcrumb-element-icon {
-        margin-right: 2px;
-      }
-    }
-
-    margin-left: 10px;
-    .ld-breadcrumb-path-separator {
-      margin-left: 10px;
-    }
-
-    flex: 0 100 auto;
-    &:last-child {
-      flex: 0 1 auto;
-
-      .ld-breadcrumb-path-separator {
-        display: none;
-      }
-    }
+  a {
+    margin-right: 5px;
   }
-
-  @media only screen and (max-width: $tablet) {
-    > li:not(:last-child) {
-      display: none;
-    }
+  li:not(:first-child) {
+    margin-left: 10px;
   }
 }
 </style>

--- a/viewer/src/components/LdCommand.vue
+++ b/viewer/src/components/LdCommand.vue
@@ -23,7 +23,12 @@
     <a class="link" :title="$t('title.search')" @click="$uiStore.toggleFullWidth()">
       <fa-icon :icon="commandToggleSearchPanelIcon()" size="lg" />
     </a>
-    <router-link to="/" :class="{'disabled': isRoot()}" :title="$t('title.home')" class="command-secondary">
+    <router-link
+      to="/"
+      class="command-secondary"
+      :class="{'disabled': isRoot()}"
+      :title="$t('title.home')"
+    >
       <fa-icon icon="home" size="lg" />
     </router-link>
     <a class="link command-secondary" :title="$t('title.back')" @click="$router.go(-1)">
@@ -58,8 +63,8 @@ export default class LdCommand extends Vue {
 </script>
 
 <style lang="scss">
-@import "@/assets/scss/theme.scss";
 @import "@/assets/scss/_buefy_variables.scss";
+@import "@/assets/scss/theme.scss";
 
 .command-btns {
   justify-content: space-around;

--- a/viewer/src/components/LdCommand.vue
+++ b/viewer/src/components/LdCommand.vue
@@ -2,6 +2,7 @@
 --             pictures into a searchable web gallery.
 --
 -- Copyright (C) 2019-2020  Guillaume FOUET
+--               2020       Pacien TRAN-GIRARD
 --
 -- This program is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as
@@ -19,15 +20,15 @@
 
 <template>
   <div class="flex command-btns">
-    <div class="link" :title="$t('title.tags')" @click="$uiStore.toggleFullWidth()">
-      <fa-icon :icon="commandTagsIcon()" size="lg" />
-    </div>
-    <router-link to="/" :class="{'disabled': isRoot()}" :title="$t('title.home')">
+    <a class="link" :title="$t('title.search')" @click="$uiStore.toggleFullWidth()">
+      <fa-icon :icon="commandToggleSearchPanelIcon()" size="lg" />
+    </a>
+    <router-link to="/" :class="{'disabled': isRoot()}" :title="$t('title.home')" class="command-secondary">
       <fa-icon icon="home" size="lg" />
     </router-link>
-    <div class="link" :title="$t('title.back')" @click="$router.go(-1)">
+    <a class="link command-secondary" :title="$t('title.back')" @click="$router.go(-1)">
       <fa-icon icon="arrow-left" size="lg" />
-    </div>
+    </a>
     <router-link :class="{'disabled': isRoot()}" :title="$t('title.parent')" :to="parent()">
       <fa-icon icon="folder" size="xs" />
       <fa-icon icon="level-up-alt" size="lg" />
@@ -41,8 +42,8 @@ import { RawLocation } from "vue-router";
 
 @Component
 export default class LdCommand extends Vue {
-  commandTagsIcon(): string {
-    return this.$uiStore.fullWidth ? "tags" : "window-close";
+  commandToggleSearchPanelIcon(): string {
+    return this.$uiStore.fullWidth ? "search" : "angle-double-left";
   }
 
   isRoot(): boolean {
@@ -58,17 +59,32 @@ export default class LdCommand extends Vue {
 
 <style lang="scss">
 @import "@/assets/scss/theme.scss";
+@import "@/assets/scss/_buefy_variables.scss";
 
 .command-btns {
   justify-content: space-around;
   vertical-align: middle;
   align-items: center;
-  width: $layout-left;
+  flex: 0 0 $layout-left;
+
+  .disabled {
+    cursor: initial;
+  }
+
   > * {
-    // Unify the minor size differences between icons
-    width: 26px;
-    height: 26px;
-    margin-top: 2px;
+    // normalise icon active boxes
+    width: $layout-top;
+    line-height: $layout-top;
+    text-align: center;
+    vertical-align: middle;
+  }
+
+  @media only screen and (max-width: $tablet) {
+    flex: 0 1;
+
+    > .command-secondary {
+      display: none;
+    }
   }
 }
 </style>

--- a/viewer/src/components/LdModeRadio.vue
+++ b/viewer/src/components/LdModeRadio.vue
@@ -21,11 +21,11 @@
   <div class="flex">
     <b-radio-button v-model="$uiStore.mode" native-value="navigation" type="is-green">
       <fa-icon icon="folder" />
-      <span>{{$t('mode.navigation')}}</span>
+      <span>Navigation</span>
     </b-radio-button>
     <b-radio-button v-model="$uiStore.mode" native-value="search" type="is-purple">
       <fa-icon icon="search" />
-      <span>{{$t('mode.search')}}</span>
+      <span>Search</span>
     </b-radio-button>
   </div>
 </template>

--- a/viewer/src/components/LdProposition.vue
+++ b/viewer/src/components/LdProposition.vue
@@ -31,12 +31,6 @@
           @click="add(Operation.SUBSTRACTION, proposed.rawTag)"
         ><fa-icon icon="minus" /></a>
 
-        <!--
-          TODO: Remove this "addition" button, as it it completely useless.
-          The suggestions are restricted on the tags present in elements in the current directory or query.
-          Performing an union on an element of this restriction is a no-op.
-          (The addition operator stays useful when elements outside of the restricted suggestions are manually entered in the input field.)
-        -->
         <a
           class="operation-btns link"
           :alt="$t('tags.action.include')"

--- a/viewer/src/components/LdProposition.vue
+++ b/viewer/src/components/LdProposition.vue
@@ -2,6 +2,7 @@
 --             pictures into a searchable web gallery.
 --
 -- Copyright (C) 2019-2020  Guillaume FOUET
+--               2020       Pacien TRAN-GIRARD
 --
 -- This program is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as
@@ -19,18 +20,40 @@
 
 <template>
   <div>
-    <div v-for="proposed in proposedTags" :key="proposed.rawTag" class="proposition">
-      <div class="operation-btns link" @click="add(Operation.SUBSTRACTION, proposed.rawTag)">
-        <fa-icon icon="minus" />
+    <div class="proposition-group">
+      <div class="proposition-group-header">{{ $t('tags.groups.uncategorised') }}</div>
+
+      <div v-for="proposed in proposedTags" :key="proposed.rawTag" class="proposition">
+        <a
+          class="operation-btns link"
+          :alt="$t('tags.action.exclude')"
+          :title="$t('tags.action.exclude')"
+          @click="add(Operation.SUBSTRACTION, proposed.rawTag)"
+        ><fa-icon icon="minus" /></a>
+
+        <!--
+          TODO: Remove this "addition" button, as it it completely useless.
+          The suggestions are restricted on the tags present in elements in the current directory or query.
+          Performing an union on an element of this restriction is a no-op.
+          (The addition operator stays useful when elements outside of the restricted suggestions are manually entered in the input field.)
+        -->
+        <a
+          class="operation-btns link"
+          :alt="$t('tags.action.include')"
+          :title="$t('tags.action.include')"
+          @click="add(Operation.ADDITION, proposed.rawTag)"
+        ><fa-icon icon="plus" /></a>
+
+        <a
+          class="operation-tag link"
+          :title="$t('tags.action.add-filter')"
+          @click="add(Operation.INTERSECTION, proposed.rawTag)"
+        >{{proposed.rawTag}}</a>
+
+        <div class="disabled proposition-count" :title="$t('tags.item-count')">
+          {{proposed.count}}
+        </div>
       </div>
-      <div class="operation-btns link" @click="add(Operation.ADDITION, proposed.rawTag)">
-        <fa-icon icon="plus" />
-      </div>
-      <div
-        class="operation-tag link"
-        @click="add(Operation.INTERSECTION, proposed.rawTag)"
-      >{{proposed.rawTag}}</div>
-      <div class="disabled">x{{proposed.count}}</div>
     </div>
   </div>
 </template>
@@ -89,20 +112,31 @@ export default class LdProposition extends Vue {
 <style lang="scss">
 @import "@/assets/scss/theme.scss";
 
-.proposition {
-  display: flex;
-  align-items: center;
-  padding-right: 7px;
-  .operation-tag {
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-    flex-grow: 1;
-    cursor: pointer;
+.proposition-group {
+  margin: 0.75em;
+
+  .proposition-group-header {
+    font-weight: bold;
   }
-  .operation-btns {
-    padding: 2px 7px;
-    cursor: pointer;
+
+  .proposition {
+    display: flex;
+    align-items: center;
+    .operation-tag {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+      flex-grow: 1;
+      cursor: pointer;
+      padding-left: 0.2em;
+    }
+    .operation-btns {
+      padding: 2px 7px;
+      cursor: pointer;
+    }
+    .proposition-count {
+      margin: 0 0.5em;
+    }
   }
 }
 </style>

--- a/viewer/src/components/LdProposition.vue
+++ b/viewer/src/components/LdProposition.vue
@@ -19,35 +19,29 @@
 -->
 
 <template>
-  <div>
-    <div class="proposition-group">
-      <div class="proposition-group-header">{{ $t('tags.groups.uncategorised') }}</div>
+  <div class="proposition-group">
+    <div v-for="proposed in proposedTags" :key="proposed.rawTag" class="proposition">
+      <a
+        class="operation-btns link"
+        :title="$t('tags.action.exclude')"
+        @click="add(Operation.SUBSTRACTION, proposed.rawTag)"
+      >
+        <fa-icon icon="minus" />
+      </a>
+      <a
+        class="operation-btns link"
+        :title="$t('tags.action.include')"
+        @click="add(Operation.ADDITION, proposed.rawTag)"
+      >
+        <fa-icon icon="plus" />
+      </a>
+      <a
+        class="operation-tag link"
+        :title="$t('tags.action.add-filter')"
+        @click="add(Operation.INTERSECTION, proposed.rawTag)"
+      >{{proposed.rawTag}}</a>
 
-      <div v-for="proposed in proposedTags" :key="proposed.rawTag" class="proposition">
-        <a
-          class="operation-btns link"
-          :alt="$t('tags.action.exclude')"
-          :title="$t('tags.action.exclude')"
-          @click="add(Operation.SUBSTRACTION, proposed.rawTag)"
-        ><fa-icon icon="minus" /></a>
-
-        <a
-          class="operation-btns link"
-          :alt="$t('tags.action.include')"
-          :title="$t('tags.action.include')"
-          @click="add(Operation.ADDITION, proposed.rawTag)"
-        ><fa-icon icon="plus" /></a>
-
-        <a
-          class="operation-tag link"
-          :title="$t('tags.action.add-filter')"
-          @click="add(Operation.INTERSECTION, proposed.rawTag)"
-        >{{proposed.rawTag}}</a>
-
-        <div class="disabled proposition-count" :title="$t('tags.item-count')">
-          {{proposed.count}}
-        </div>
-      </div>
+      <div class="disabled" :title="$t('tags.item-count')">{{proposed.count}}</div>
     </div>
   </div>
 </template>
@@ -107,30 +101,23 @@ export default class LdProposition extends Vue {
 @import "@/assets/scss/theme.scss";
 
 .proposition-group {
-  margin: 0.75em;
-
-  .proposition-group-header {
-    font-weight: bold;
-  }
+  margin: 0.25em;
 
   .proposition {
     display: flex;
     align-items: center;
-    .operation-tag {
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      overflow: hidden;
-      flex-grow: 1;
-      cursor: pointer;
-      padding-left: 0.2em;
-    }
-    .operation-btns {
-      padding: 2px 7px;
-      cursor: pointer;
-    }
-    .proposition-count {
-      margin: 0 0.5em;
-    }
+  }
+  .operation-tag {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    flex-grow: 1;
+    cursor: pointer;
+    padding-left: 0.2em;
+  }
+  .operation-btns {
+    padding: 2px 7px;
+    cursor: pointer;
   }
 }
 </style>

--- a/viewer/src/components/LdTagInput.vue
+++ b/viewer/src/components/LdTagInput.vue
@@ -28,7 +28,6 @@
     :data="filteredTags"
     field="display"
     size="is-medium"
-    class="paneltag-input"
     @typing="searchTags"
     @add="onAdd"
     @remove="onRemove"
@@ -119,32 +118,4 @@ export default class LdTagInput extends Vue {
 </script>
 
 <style lang="scss">
-@import "@/assets/scss/theme.scss";
-
-.paneltag-input {
-  .taginput-container.is-focusable {
-    box-shadow: none !important;
-    border-color: transparent !important;
-
-    &.is-focused {
-      border-color: $input-active-outline-color !important;
-    }
-  }
-
-  .tag {
-    background-color: $input-tag-background-color;
-
-    &.is-delete {
-      background-color: $input-tag-delete-background-color !important;
-
-      &:hover {
-        color: $link-hover;
-      }
-    }
-  }
-
-  .paneltag-input .autocomplete .dropdown-content {
-    max-height: 300px;
-  }
-}
 </style>

--- a/viewer/src/components/LdTagInput.vue
+++ b/viewer/src/components/LdTagInput.vue
@@ -2,6 +2,7 @@
 --             pictures into a searchable web gallery.
 --
 -- Copyright (C) 2019-2020  Guillaume FOUET
+--               2020       Pacien TRAN-GIRARD
 --
 -- This program is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as
@@ -26,7 +27,6 @@
     attached
     :data="filteredTags"
     field="display"
-    type="is-black"
     size="is-medium"
     class="paneltag-input"
     @typing="searchTags"
@@ -119,7 +119,32 @@ export default class LdTagInput extends Vue {
 </script>
 
 <style lang="scss">
-.paneltag-input .autocomplete .dropdown-content {
-  max-height: 300px;
+@import "@/assets/scss/theme.scss";
+
+.paneltag-input {
+  .taginput-container.is-focusable {
+    box-shadow: none !important;
+    border-color: transparent !important;
+
+    &.is-focused {
+      border-color: $input-active-outline-color !important;
+    }
+  }
+
+  .tag {
+    background-color: $input-tag-background-color;
+
+    &.is-delete {
+      background-color: $input-tag-delete-background-color !important;
+
+      &:hover {
+        color: $link-hover;
+      }
+    }
+  }
+
+  .paneltag-input .autocomplete .dropdown-content {
+    max-height: 300px;
+  }
 }
 </style>

--- a/viewer/src/locales/en.json
+++ b/viewer/src/locales/en.json
@@ -1,15 +1,15 @@
 {
-  "tagInput.placeholder": "Tags",
-  "panelLeft.filters": "Filters",
+  "tagInput.placeholder": "Filters",
   "tagInput.nomatch": "No match",
-  "panelLeft.mode": "Mode",
-  "mode.navigation": "Navigation",
-  "mode.search": "Search",
+  "tags.action.exclude": "Exclude from results",
+  "tags.action.include": "Include in results",
+  "tags.action.add-filter": "Add tag to filters",
+  "tags.item-count": "Item count",
+  "tags.groups.uncategorised": "Uncategorised tags",
   "search.no-results": "No results",
-  "panelLeft.propositions": "Proposed tags",
   "gallery.unknowntype": "Unknown item type",
-  "title.tags": "Tags",
-  "title.home": "Home",
-  "title.back": "Back",
-  "title.parent": "Parent"
+  "title.search": "Open search panel",
+  "title.home": "Go to home",
+  "title.back": "Go back",
+  "title.parent": "Go to parent directory"
 }

--- a/viewer/src/locales/en.json
+++ b/viewer/src/locales/en.json
@@ -11,5 +11,6 @@
   "title.search": "Open search panel",
   "title.home": "Go to home",
   "title.back": "Go back",
-  "title.parent": "Go to parent directory"
+  "title.parent": "Go to parent directory",
+  "panelLeft.propositions": "Proposed tags"
 }

--- a/viewer/src/plugins/fontawesome.ts
+++ b/viewer/src/plugins/fontawesome.ts
@@ -30,9 +30,8 @@ import {
     faHome,
     faArrowLeft,
     faLevelUpAlt,
-    faTags,
     faAngleRight,
-    faWindowClose,
+    faAngleDoubleLeft,
     faFile,
 } from "@fortawesome/free-solid-svg-icons";
 
@@ -45,9 +44,8 @@ library.add(
     faHome,
     faArrowLeft,
     faLevelUpAlt,
-    faTags,
     faAngleRight,
-    faWindowClose,
+    faAngleDoubleLeft,
     faFile,
 );
 

--- a/viewer/src/views/GalleryDirectory.vue
+++ b/viewer/src/views/GalleryDirectory.vue
@@ -24,9 +24,6 @@
         <ld-thumbnail :item="item" />
       </router-link>
     </div>
-    <div>
-      <!-- Empty item for better flex layout -->
-    </div>
   </div>
 </template>
 

--- a/viewer/src/views/GallerySearch.vue
+++ b/viewer/src/views/GallerySearch.vue
@@ -25,9 +25,6 @@
       </router-link>
     </div>
     <div v-if="items.length===0">{{$t('search.no-results')}}</div>
-    <div>
-      <!-- Empty item for better flex layout -->
-    </div>
   </div>
 </template>
 

--- a/viewer/src/views/MainLayout.vue
+++ b/viewer/src/views/MainLayout.vue
@@ -2,6 +2,7 @@
 --             pictures into a searchable web gallery.
 --
 -- Copyright (C) 2019-2020  Guillaume FOUET
+--               2020       Pacien TRAN-GIRARD
 --
 -- This program is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as
@@ -115,7 +116,7 @@ html {
     background-color: $panel-top-bgcolor;
     color: $panel-top-txtcolor;
   }
-  &.layout-left {
+  &.layout-left, &.layout-top > *:first-child {
     background-color: $panel-left-bgcolor;
     color: $panel-left-txtcolor;
   }

--- a/viewer/src/views/MainLayout.vue
+++ b/viewer/src/views/MainLayout.vue
@@ -116,7 +116,7 @@ html {
     background-color: $panel-top-bgcolor;
     color: $panel-top-txtcolor;
   }
-  &.layout-left, &.layout-top > *:first-child {
+  &.layout-left {
     background-color: $panel-left-bgcolor;
     color: $panel-left-txtcolor;
   }

--- a/viewer/src/views/PanelLeft.vue
+++ b/viewer/src/views/PanelLeft.vue
@@ -20,18 +20,10 @@
 
 <template>
   <div class="flex-column">
-    <ld-tag-input />
-    <ld-proposition class="scrollbar no-scroll-x" />
-
-    <!--
-    --  TODO: just remove the following "mode" switch: manually toggling it leads to inconsistent views.
-    --  The two modes should instead be made clear by the use of the breadcrumbs: the path would not appear anymore during searches.
-    --  Entering any query already switches automatically into search mode.
-    --  It is already possible to exit the search mode by clearing the filters, either by using the home, back and up navigation buttons, or manually by removing the tags in the input fieds.
-
     <ld-mode-radio />
-    -->
-
+    <ld-tag-input />
+    <h1 class="title">{{$t('panelLeft.propositions')}}</h1>
+    <ld-proposition class="scrollbar no-scroll-x" />
   </div>
 </template>
 

--- a/viewer/src/views/PanelLeft.vue
+++ b/viewer/src/views/PanelLeft.vue
@@ -24,12 +24,13 @@
     <ld-proposition class="scrollbar no-scroll-x" />
 
     <!--
-      TODO: just remove the following "mode" switch: manually toggling it leads to inconsistent views.
-      The two modes should instead be made clear by the use of the breadcrumbs: the path would not appear anymore during searches.
-      Entering any query already switches automatically into search mode.
-      It is already possible to exit the search mode by clearing the filters, either by using the home, back and up navigation buttons, or manually by removing the tags in the input fieds.
+    --  TODO: just remove the following "mode" switch: manually toggling it leads to inconsistent views.
+    --  The two modes should instead be made clear by the use of the breadcrumbs: the path would not appear anymore during searches.
+    --  Entering any query already switches automatically into search mode.
+    --  It is already possible to exit the search mode by clearing the filters, either by using the home, back and up navigation buttons, or manually by removing the tags in the input fieds.
+
+    <ld-mode-radio />
     -->
-    <ld-mode-radio style="opacity: 0.5; position: absolute; bottom: 0; z-index: -1;" />
 
   </div>
 </template>

--- a/viewer/src/views/PanelLeft.vue
+++ b/viewer/src/views/PanelLeft.vue
@@ -2,6 +2,7 @@
 --             pictures into a searchable web gallery.
 --
 -- Copyright (C) 2019-2020  Guillaume FOUET
+--               2020       Pacien TRAN-GIRARD
 --
 -- This program is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as
@@ -19,12 +20,17 @@
 
 <template>
   <div class="flex-column">
-    <h1>{{$t('panelLeft.mode')}}</h1>
-    <ld-mode-radio />
-    <h1>{{$t('panelLeft.filters')}}</h1>
     <ld-tag-input />
-    <h1>{{$t('panelLeft.propositions')}}</h1>
     <ld-proposition class="scrollbar no-scroll-x" />
+
+    <!--
+      TODO: just remove the following "mode" switch: manually toggling it leads to inconsistent views.
+      The two modes should instead be made clear by the use of the breadcrumbs: the path would not appear anymore during searches.
+      Entering any query already switches automatically into search mode.
+      It is already possible to exit the search mode by clearing the filters, either by using the home, back and up navigation buttons, or manually by removing the tags in the input fieds.
+    -->
+    <ld-mode-radio style="opacity: 0.5; position: absolute; bottom: 0; z-index: -1;" />
+
   </div>
 </template>
 


### PR DESCRIPTION
* Responsiveness: make the top bar command buttons and breadcrumbs
  progressive (part of GitHub #20)
* Accessibility: use "a" elements when relevant to make keyboard
  navigation possible
* Accessibility: clarify button actions with "alt" and "title"
  attributes (GitHub closes #23)
* Accessibility: fix reactive boxes for touchscreens
* Tag groups: prepare style to support tag groups (part of GitHub #29)
* Add generator meta tag (without version) (part of GitHub #33)
* Theming: change colour theme based on palettes
* Theming: use more explicit action icons
* Deprecate view mode manual toggle
* Theming: fix stuck `:hover` after touch (closes #94)