### PR TITLE
viewer: fix sticky hover styling on links

### DIFF
--- a/viewer/src/assets/scss/global.scss
+++ b/viewer/src/assets/scss/global.scss
@@ -62,6 +62,19 @@
   color: $disabled-color !important;
 }
 
+// Disable sticky hover styling on touch devices,
+// on which the virtual cursor doesn't leave the element after being tapped.
+// The fix can be applied to `a` elements by using the .link class.
+@media (hover:none), (hover:on-demand) {
+  .link:hover {
+    color: $link !important;
+  }
+￼
+  .disabled:hover {
+    color: $disabled-color !important;
+  }
+}
+
 // === Scrollbar styling
 
 .scrollbar {


### PR DESCRIPTION
This disables sticky hover styling on touch devices,
on which the virtual cursor doesn't leave the element after being tapped.
The fix can be applied to  elements by using the .link class.

GitHub: closes #94