### PR TITLE
viewer: tag index bugfix

### DIFF
--- a/viewer/src/components/LdCommand.vue
+++ b/viewer/src/components/LdCommand.vue
@@ -55,7 +55,7 @@ export default class LdCommand extends Vue {
   }
 
   isEntryPoint(): boolean {
-    return history.state.ldgallery === "ENTRYPOINT"; // Set by MainLayout.vue
+    return history.state?.ldgallery === "ENTRYPOINT"; // Set by MainLayout.vue
   }
 
   parent(): RawLocation {

--- a/viewer/src/components/LdTagInput.vue
+++ b/viewer/src/components/LdTagInput.vue
@@ -55,7 +55,7 @@ export default class LdTagInput extends Vue {
   }
 
   searchTags(filter: string) {
-    this.filteredTags = IndexFactory.searchTags(this.tagsIndex, filter)
+    this.filteredTags = IndexFactory.searchTags(this.tagsIndex, filter, false)
       .filter(newSearch => !this.model.find(currentSearch => currentSearch.tag === newSearch.tag))
       .sort((a, b) => b.items.length - a.items.length);
   }

--- a/viewer/src/views/GalleryNavigation.vue
+++ b/viewer/src/views/GalleryNavigation.vue
@@ -49,7 +49,6 @@ export default class GalleryNavigation extends Vue {
 
   @Watch("path")
   pathChanged() {
-    console.log("Path: ", this.path);
     this.$galleryStore.setCurrentPath(this.path);
   }
 

--- a/viewer/src/views/PanelLeft.vue
+++ b/viewer/src/views/PanelLeft.vue
@@ -72,7 +72,7 @@ export default class PanelLeft extends Vue {
     const query = Object.keys(route.query);
     if (query.length > 0) {
       const tagsIndex = this.$galleryStore.tagsIndex;
-      this.searchFilters = Object.keys(route.query).flatMap(filter => IndexFactory.searchTags(tagsIndex, filter));
+      this.searchFilters = Object.keys(route.query).flatMap(filter => IndexFactory.searchTags(tagsIndex, filter, true));
       this.$galleryStore.setCurrentSearch([...this.searchFilters]);
     }
   }


### PR DESCRIPTION
Search from the URL requires a strict match instead of a loose match
Category search was case sensitive
Category + disambiguation was matching like an intersection of both tags instead of being hard-coupled
Removed the logs for the release (coming soon)