### PR TITLE
viewer: fix touchpad scroll in filter proposition list

### DIFF
--- a/viewer/src/views/PanelLeft.vue
+++ b/viewer/src/views/PanelLeft.vue
@@ -26,7 +26,7 @@
     />
     <ld-command-search @clear="clear" @search="search" />
     <h1 class="title">{{$t('panelLeft.propositions')}}</h1>
-    <div v-dragscroll class="scrollbar no-scroll-x">
+    <div class="scrollbar no-scroll-x">
       <ld-proposition
         v-for="(category) in $galleryStore.tagsCategories"
         :key="category.tag"


### PR DESCRIPTION
Dragscroll plays badly with touchpads and brings no benefit on desktop.
It is still supported on touchscreen devices natively in the presence of the
scrollbars.

GitHub: closes #185