### PR TITLE
compiler: reuse derived item properties from last compilation 

### DIFF
--- a/compiler/src/Caching.hs
+++ b/compiler/src/Caching.hs
@@ -1,0 +1,56 @@
+-- ldgallery - A static generator which turns a collection of tagged
+--             pictures into a searchable web gallery.
+--
+-- Copyright (C) 2019-2020  Pacien TRAN-GIRARD
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+module Caching
+  ( Cache
+  , skipCache
+  , withCache
+  ) where
+
+
+import Control.Monad (when)
+import System.Directory (removePathForcibly, doesDirectoryExist, doesFileExist)
+
+import FileProcessors (FileProcessor)
+import Files
+
+
+type Cache = FileProcessor -> FileProcessor
+
+skipCache :: Cache
+skipCache processor inputPath outputPath =
+  removePathForcibly outputPath
+  >> processor inputPath outputPath
+
+withCache :: Cache
+withCache processor inputPath outputPath =
+  do
+    isDir <- doesDirectoryExist outputPath
+    when isDir $ removePathForcibly outputPath
+
+    fileExists <- doesFileExist outputPath
+    if fileExists then
+      do
+        needUpdate <- isOutdated True inputPath outputPath
+        if needUpdate then update else skip
+    else
+      update
+
+  where
+    update = processor inputPath outputPath
+    skip = putStrLn $ "Skipping:\t" ++ outputPath

--- a/compiler/src/Compiler.hs
+++ b/compiler/src/Compiler.hs
@@ -43,9 +43,8 @@ import Files
   , nodeName
   , filterDir
   , ensureParentDir )
-import Processors
-  ( itemFileProcessor, thumbnailFileProcessor
-  , skipCached, withCached )
+import ItemProcessors (itemFileProcessor, thumbnailFileProcessor)
+import Caching (skipCache, withCache)
 
 
 defaultGalleryConf :: String
@@ -127,7 +126,7 @@ compileGallery configPath inputDirPath outputDirPath outputIndexPath excludedDir
     inputTree <- readInputTree sourceTree
     let curatedInputTree = filterInputTree (inputTreeFilter config) inputTree
 
-    let cache = if rebuildAll then skipCached else withCached
+    let cache = if rebuildAll then skipCache else withCache
     let itemProc = itemProcessor config cache
     let thumbnailProc = thumbnailProcessor config cache
     let galleryBuilder = buildGalleryTree itemProc thumbnailProc (tagsFromDirectories config)

--- a/compiler/src/Compiler.hs
+++ b/compiler/src/Compiler.hs
@@ -29,7 +29,7 @@ import System.FilePath ((</>))
 import qualified System.FilePath.Glob as Glob
 import System.Directory (canonicalizePath)
 
-import Data.Aeson (ToJSON)
+import Data.Aeson (ToJSON, FromJSON)
 import qualified Data.Aeson as JSON
 
 import Config
@@ -64,7 +64,7 @@ thumbnailsDir = "thumbnails"
 data GalleryIndex = GalleryIndex
   { properties :: ViewerConfig
   , tree :: GalleryItem
-  } deriving (Generic, Show, ToJSON)
+  } deriving (Generic, Show, ToJSON, FromJSON)
 
 
 writeJSON :: ToJSON a => FileName -> a -> IO ()

--- a/compiler/src/Compiler.hs
+++ b/compiler/src/Compiler.hs
@@ -24,17 +24,25 @@ module Compiler
 
 import GHC.Generics (Generic)
 import Control.Monad (liftM2, when)
+import Data.Bool (bool)
 import Data.Maybe (fromMaybe)
 import System.FilePath ((</>))
 import qualified System.FilePath.Glob as Glob
-import System.Directory (canonicalizePath)
+import System.Directory (canonicalizePath, doesFileExist)
 
 import Data.Aeson (ToJSON, FromJSON)
 import qualified Data.Aeson as JSON
 
 import Config
 import Input (InputTree, readInputTree, filterInputTree, sidecar, tags)
-import Resource (GalleryItem, buildGalleryTree, galleryCleanupResourceDir)
+import Resource
+  ( GalleryItem
+  , GalleryItemProps
+  , Thumbnail
+  , buildGalleryTree
+  , galleryCleanupResourceDir
+  , properties
+  , thumbnail)
 import Files
   ( FileName
   , FSNode(..)
@@ -43,8 +51,8 @@ import Files
   , nodeName
   , filterDir
   , ensureParentDir )
-import ItemProcessors (itemFileProcessor, thumbnailFileProcessor)
-import Caching (skipCache, withCache)
+import ItemProcessors (ItemProcessor, itemFileProcessor, thumbnailFileProcessor)
+import Caching (Cache, noCache, buildItemCache, useCached)
 
 
 defaultGalleryConf :: String
@@ -71,6 +79,15 @@ writeJSON outputPath object =
   do
     putStrLn $ "Generating:\t" ++ outputPath
     ensureParentDir JSON.encodeFile outputPath object
+
+loadGalleryIndex :: FilePath -> IO (Maybe GalleryIndex)
+loadGalleryIndex path =
+  doesFileExist path >>= bool (return Nothing) decodeIndex
+  where
+    decodeIndex =
+      JSON.eitherDecodeFileStrict path
+      >>= either (\err -> warn err >> return Nothing) (return . Just)
+    warn = putStrLn . ("Warning:\tUnable to reuse existing index as cache: " ++)
 
 
 (&&&) :: (a -> Bool) -> (a -> Bool) -> a -> Bool
@@ -126,14 +143,17 @@ compileGallery configPath inputDirPath outputDirPath outputIndexPath excludedDir
     inputTree <- readInputTree sourceTree
     let curatedInputTree = filterInputTree (inputTreeFilter config) inputTree
 
-    let cache = if rebuildAll then skipCache else withCache
-    let itemProc = itemProcessor config cache
-    let thumbnailProc = thumbnailProcessor config cache
+    let galleryIndexPath = outputGalleryIndex outputIndexPath
+    cachedIndex <- loadCachedIndex galleryIndexPath
+    let cache = mkCache cachedIndex
+
+    let itemProc = itemProcessor config (cache Resource.properties)
+    let thumbnailProc = thumbnailProcessor config (cache Resource.thumbnail)
     let galleryBuilder = buildGalleryTree itemProc thumbnailProc (tagsFromDirectories config)
     resources <- galleryBuilder curatedInputTree
 
     when cleanOutput $ galleryCleanupResourceDir resources outputDirPath
-    writeJSON (outputGalleryIndex outputIndexPath) $ GalleryIndex (viewerConfig config) resources
+    writeJSON galleryIndexPath $ GalleryIndex (viewerConfig config) resources
 
   where
     inputGalleryConf :: FilePath -> FilePath
@@ -144,10 +164,25 @@ compileGallery configPath inputDirPath outputDirPath outputIndexPath excludedDir
     outputGalleryIndex "" = outputDirPath </> defaultIndexFile
     outputGalleryIndex file = file
 
+    loadCachedIndex :: FilePath -> IO (Maybe GalleryIndex)
+    loadCachedIndex galleryIndexPath =
+      if rebuildAll
+        then return Nothing
+        else loadGalleryIndex galleryIndexPath
+
+    mkCache :: Maybe GalleryIndex -> (GalleryItem -> a) -> Cache a
+    mkCache refGalleryIndex =
+      if rebuildAll
+        then const noCache
+        else useCached (buildItemCache $ fmap tree refGalleryIndex)
+
+    itemProcessor :: GalleryConfig -> Cache GalleryItemProps -> ItemProcessor GalleryItemProps
     itemProcessor config cache =
       itemFileProcessor
         (pictureMaxResolution config) cache
         inputDirPath outputDirPath itemsDir
+
+    thumbnailProcessor :: GalleryConfig -> Cache (Maybe Thumbnail) -> ItemProcessor (Maybe Thumbnail)
     thumbnailProcessor config cache =
       thumbnailFileProcessor
         (thumbnailMaxResolution config) cache

--- a/compiler/src/Config.hs
+++ b/compiler/src/Config.hs
@@ -84,7 +84,7 @@ readConfig = decodeYamlFile
 data ViewerConfig = ViewerConfig
   { galleryTitle :: String
   , tagCategories :: [String]
-  } deriving (Generic, ToJSON, Show)
+  } deriving (Generic, ToJSON, FromJSON, Show)
 
 viewerConfig :: GalleryConfig -> ViewerConfig
 viewerConfig GalleryConfig{galleryTitle, tagCategories} = ViewerConfig galleryTitle tagCategories

--- a/compiler/src/FileProcessors.hs
+++ b/compiler/src/FileProcessors.hs
@@ -1,0 +1,95 @@
+-- ldgallery - A static generator which turns a collection of tagged
+--             pictures into a searchable web gallery.
+--
+-- Copyright (C) 2019-2020  Pacien TRAN-GIRARD
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as
+-- published by the Free Software Foundation, either version 3 of the
+-- License, or (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+module FileProcessors
+  ( FileProcessor
+  , copyFileProcessor
+  , resizePictureUpTo
+  , resourceAt
+  , getImageResolution
+  , ItemDescriber
+  , getPictureProps
+  ) where
+
+
+import Control.Exception (Exception, throwIO)
+import System.Process (readProcess, callProcess)
+import Text.Read (readMaybe)
+
+import System.Directory (getModificationTime)
+import qualified System.Directory
+
+import Config (Resolution(..))
+import Resource (Resource(..), GalleryItemProps(..))
+import Files
+
+
+data ProcessingException = ProcessingException FilePath String deriving Show
+instance Exception ProcessingException
+
+type FileProcessor =
+     FileName -- ^ Input path
+  -> FileName -- ^ Output path
+  -> IO ()
+
+copyFileProcessor :: FileProcessor
+copyFileProcessor inputPath outputPath =
+  putStrLn ("Copying:\t" ++ outputPath)
+  >> ensureParentDir (flip System.Directory.copyFile) outputPath inputPath
+
+resizePictureUpTo :: Resolution -> FileProcessor
+resizePictureUpTo maxResolution inputPath outputPath =
+  putStrLn ("Generating:\t" ++ outputPath)
+  >> ensureParentDir (flip resize) outputPath inputPath
+  where
+    maxSize :: Resolution -> String
+    maxSize Resolution{width, height} = show width ++ "x" ++ show height ++ ">"
+
+    resize :: FileName -> FileName -> IO ()
+    resize input output = callProcess "magick"
+      [ input
+      , "-auto-orient"
+      , "-resize", maxSize maxResolution
+      , output ]
+
+
+resourceAt :: FilePath -> Path -> IO Resource
+resourceAt fsPath resPath = Resource resPath <$> getModificationTime fsPath
+
+getImageResolution :: FilePath -> IO Resolution
+getImageResolution fsPath =
+  readProcess "magick" ["identify", "-format", "%w %h", firstFrame] []
+  >>= parseResolution . break (== ' ')
+  where
+    firstFrame :: FilePath
+    firstFrame = fsPath ++ "[0]"
+
+    parseResolution :: (String, String) -> IO Resolution
+    parseResolution (widthString, heightString) =
+      case (readMaybe widthString, readMaybe heightString) of
+        (Just w, Just h) -> return $ Resolution w h
+        _ -> throwIO $ ProcessingException fsPath "Unable to read image resolution."
+
+
+type ItemDescriber =
+     FilePath
+  -> Resource
+  -> IO GalleryItemProps
+
+getPictureProps :: ItemDescriber
+getPictureProps fsPath resource = Picture resource <$> getImageResolution fsPath

--- a/compiler/src/Files.hs
+++ b/compiler/src/Files.hs
@@ -28,7 +28,7 @@ module Files
   ) where
 
 
-import Data.List (isPrefixOf, length, subsequences, sortOn)
+import Data.List (isPrefixOf, length, sortOn)
 import Data.Function ((&))
 import Data.Functor ((<&>))
 import Data.Text (pack)
@@ -81,7 +81,10 @@ fileName (Path (name:_)) = Just name
 fileName _ = Nothing
 
 subPaths :: Path -> [Path]
-subPaths (Path path) = map Path $ subsequences path
+subPaths (Path path) = map Path $ subpaths path
+  where
+    subpaths [] = []
+    subpaths full@(_:r) = full : subpaths r
 
 pathLength :: Path -> Int
 pathLength (Path path) = Data.List.length path

--- a/compiler/src/Input.hs
+++ b/compiler/src/Input.hs
@@ -28,7 +28,7 @@ import Control.Exception (Exception, AssertionFailed(..), throw, throwIO)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Function ((&))
 import Data.Functor ((<&>))
-import Data.Maybe (catMaybes)
+import Data.Maybe (catMaybes, fromMaybe)
 import Data.Bool (bool)
 import Data.List (find)
 import Data.Time.Clock (UTCTime)
@@ -91,7 +91,7 @@ readSidecarFile :: FilePath -> IO Sidecar
 readSidecarFile filepath =
   doesFileExist filepath
   >>= bool (return Nothing) (decodeYamlFile filepath)
-  <&> maybe emptySidecar id
+  <&> fromMaybe emptySidecar
 
 
 readInputTree :: AnchoredFSNode -> IO InputTree


### PR DESCRIPTION
A benchmark on an already bulit gallery with ~600 pictures shows a ~90% speedup:

Before:

    Time (mean ± σ):      2.879 s ±  0.125 s    [User: 14.686 s, System: 5.511 s]
    Range (min … max):    2.774 s …  3.203 s    10 runs

After:

    Time (mean ± σ):     289.5 ms ±  15.1 ms    [User: 596.1 ms, System: 359.3 ms]
    Range (min … max):   272.8 ms … 323.0 ms    10 runs

---

GitHub: closes #97
\+ some refactoring

---

@OzoneGrif please test and compare perfs before/after on your big gallery over that slow SMB share