### PR TITLE
viewer/services/itemComparators: make the orders linear

### DIFF
--- a/example/config.json
+++ b/example/config.json
@@ -1,6 +1,6 @@
 {
     "galleryRoot": "out/",
     "galleryIndex": "index.json",
-    "initialItemSort": "date_desc",
+    "initialItemSort": "date_asc",
     "initialTagDisplayLimit": 10
 }

--- a/viewer/ldgallery-viewer.7.md
+++ b/viewer/ldgallery-viewer.7.md
@@ -2,7 +2,7 @@
 pagetitle: Viewer user manual - ldgallery
 title: LDGALLERY-VIEWER(7) ldgallery
 author: Pacien TRAN-GIRARD, Guillaume FOUET
-date: 2020-09-19 (v2.0)
+date: 2020-09-24 (v2.0)
 ---
 
 
@@ -79,6 +79,7 @@ initialItemSort
   Possible values are "title_asc", "date_asc", "date_desc".
   Defaults to "title_asc".
   Titles are sorted using a human-friendly _natural sort order_ which treats multi-digit numbers atomically.
+  The item path is used as a tie-breaker for all the defined orders.
 
 <!-- https://github.com/pacien/ldgallery/issues/27
 initialSearchQuery

--- a/viewer/ldgallery-viewer.7.md
+++ b/viewer/ldgallery-viewer.7.md
@@ -77,7 +77,7 @@ galleryIndex
 initialItemSort
 : Order in which gallery items are originally to be displayed.
   Possible values are "title_asc", "date_asc", "date_desc".
-  Defaults to "title_asc".
+  Defaults to "date_asc".
   Titles are sorted using a human-friendly _natural sort order_ which treats multi-digit numbers atomically.
   The item path is used as a tie-breaker for all the defined orders.
 

--- a/viewer/src/services/itemComparators.ts
+++ b/viewer/src/services/itemComparators.ts
@@ -41,7 +41,7 @@ export default class ItemComparators {
     },
   ];
 
-  static readonly DEFAULT = ItemComparators.ITEM_SORTS[0].fn;
+  static readonly DEFAULT = ItemComparators.ITEM_SORTS[1].fn;
 
   static sortByPathAsc(left: Gallery.Item, right: Gallery.Item): number {
     return left.path.localeCompare(right.path, undefined, {


### PR DESCRIPTION
By using the item path as a tie-breaker.

GitHub: closes #255